### PR TITLE
Small change to the sbt build file

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -27,7 +27,7 @@ object Build extends sbt.Build {
 
 object Dependencies {
   val resolutionRepos = Seq(
-    "Akka Repository" at "http://akka.io/repository/",
+    "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/",
     ScalaToolsSnapshots
   )
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,12 +1,16 @@
 import sbt._
+import com.github.siasia._
+import WebPlugin._
+import PluginKeys._
 import Keys._
-import com.github.siasia.WebPlugin
 
 object Build extends sbt.Build {
   import Dependencies._
 
+
   lazy val myProject = Project("spray-template", file("."))
     .settings(WebPlugin.webSettings: _*)
+    .settings(port in config("container")  := 8080)
     .settings(
       organization  := "com.example",
       version       := "0.8.0",
@@ -23,6 +27,7 @@ object Build extends sbt.Build {
         Container.logback
       )
     )
+    
 }
 
 object Dependencies {


### PR DESCRIPTION
changed the repository for akka to the one actually containing the 1.2 release at the moment. Also explicitly configured the portnumber runs on.
