### PR TITLE
Updated sbt-revolver repository from cc.spray to io.spray

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("cc.spray" % "sbt-revolver" % "0.6.2")
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.6.2")


### PR DESCRIPTION
The sbt-revolver plugin now lives under 'io.spray' instead of 'cc.spray' - this template fails to build with a virgin ivy cache unless this is changed.

(I'm quite new to Spray, and SBT in general, so forgive me if this is in error).
