### PR TITLE
move testkits to 'test' scope

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,9 +13,9 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   "io.spray"            %   "spray-can"     % "1.2-M8",
   "io.spray"            %   "spray-routing" % "1.2-M8",
-  "io.spray"            %   "spray-testkit" % "1.2-M8",
+  "io.spray"            %   "spray-testkit" % "1.2-M8" % "test",
   "com.typesafe.akka"   %%  "akka-actor"    % "2.2.0-RC1",
-  "com.typesafe.akka"   %%  "akka-testkit"  % "2.2.0-RC1",
+  "com.typesafe.akka"   %%  "akka-testkit"  % "2.2.0-RC1" % "test",
   "org.specs2"          %%  "specs2"        % "1.14" % "test"
 )
 


### PR DESCRIPTION
Testkits are not required in production code, lets declare it 
in `test` scope
