### PR TITLE
switch spray-testkit and akka-testkit to 'test' scope

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -34,7 +34,7 @@ Follow these steps to get started:
 
         > re-start
 
-6. Browse to http://localhost:8080/
+6. Browse to [http://localhost:8080](http://localhost:8080/)
 
 7. Stop the application:
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,9 +16,9 @@ libraryDependencies ++= {
   Seq(
     "io.spray"            %   "spray-can"     % sprayV,
     "io.spray"            %   "spray-routing" % sprayV,
-    "io.spray"            %   "spray-testkit" % sprayV,
+    "io.spray"            %   "spray-testkit" % sprayV  % "test",
     "com.typesafe.akka"   %%  "akka-actor"    % akkaV,
-    "com.typesafe.akka"   %%  "akka-testkit"  % akkaV,
+    "com.typesafe.akka"   %%  "akka-testkit"  % akkaV   % "test",
     "org.specs2"          %%  "specs2"        % "2.2.3" % "test"
   )
 }


### PR DESCRIPTION
Hi,

I'd like to point to a minor improvement in the sbt file, you can switch the 2 test dependencies to 'test' scope.
Also, I've transformed the localhost into a link on the readme, but that's just cosmetics.

thanks!
