### PR TITLE
example of detach and future for asynchronous request processing

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -3,5 +3,5 @@ akka {
 }
 
 spray.can.server {
-  request-timeout = 1s
+  request-timeout = 10s
 }

--- a/src/main/scala/com/example/MyService.scala
+++ b/src/main/scala/com/example/MyService.scala
@@ -1,9 +1,13 @@
 package com.example
 
-import akka.actor.Actor
+import akka.actor.{ActorContext, Actor}
 import spray.routing._
 import spray.http._
 import MediaTypes._
+import scala.util.Success
+import scala.concurrent.{ ExecutionContext, Future, Promise }
+import ExecutionContext.Implicits.global
+import spray.util.LoggingContext
 
 // we don't implement our route structure directly in the service actor because
 // we want to be able to test it independently, without having to spin up an actor
@@ -35,6 +39,29 @@ trait MyService extends HttpService {
             </html>
           }
         }
+      }
+    } ~
+    path("test-detach" / LongNumber) { id =>
+      get {
+        println(s"detach-out ${Thread.currentThread().getName}")
+        detach(global) {
+          println(s"detach-in-1 ${Thread.currentThread().getName}")
+          Thread.sleep(5000)
+          println(s"detach-in-2 ${Thread.currentThread().getName}")
+          complete("OK")
+        }
+      }
+    } ~
+    path("test-future" / LongNumber) { id =>
+      get { ctx =>
+        println(s"future-out ${Thread.currentThread().getName}")
+        Future({
+          println(s"future-in-1 ${Thread.currentThread().getName}")
+          Thread.sleep(5000)
+          println(s"future-in-2 ${Thread.currentThread().getName}")
+          ctx.complete("OK")
+        })(global)
+        println(s"future-out-2 ${Thread.currentThread().getName}")
       }
     }
 }


### PR DESCRIPTION
This PR demonstrates strange behavior of detach spray directive.

For detach (https://github.com/ttyusupov/spray-template/blob/ty-detach-example/src/main/scala/com/example/MyService.scala#L44) processing is done within the same thread as routing:

``` shell
$ curl http://localhost:8080/test-detach/1
OK
```

logs:

```
detach-out on-spray-can-akka.actor.default-dispatcher-4
detach-in-1 on-spray-can-akka.actor.default-dispatcher-4
detach-in-2 on-spray-can-akka.actor.default-dispatcher-4
```

For future (https://github.com/ttyusupov/spray-template/blob/ty-detach-example/src/main/scala/com/example/MyService.scala#L55) processing is done concurrently in separate thread:

``` shell
$ curl http://localhost:8080/test-detach/1
OK
```

logs:

```
future-out on-spray-can-akka.actor.default-dispatcher-7
future-out-2 on-spray-can-akka.actor.default-dispatcher-7
future-in-1 ForkJoinPool-2-worker-7
future-in-2 ForkJoinPool-2-worker-7
```
